### PR TITLE
:sparkles: make imageview fitted to number of image

### DIFF
--- a/src/pages/ItemPage.tsx
+++ b/src/pages/ItemPage.tsx
@@ -24,7 +24,6 @@ const ItemPage = () => {
     'https://via.placeholder.com/400',
     'https://via.placeholder.com/500',
     'https://via.placeholder.com/600',
-    'https://via.placeholder.com/700',
   ];
   const profileimage = 'https://via.placeholder.com/100';
   const price = 1200000;
@@ -87,7 +86,7 @@ const ItemPage = () => {
         <div
           className={styles.imagewrapper}
           style={{
-            transform: `translateX(calc(-${currentImageIndex * 100}vw + 200vw))`,
+            transform: `translateX(calc(-${currentImageIndex * 100}vw + ${(images.length - 1) * 50}vw))`,
           }}
         >
           {images.map((src, index) => (


### PR DESCRIPTION
# 📌 Pull Request Template


## 📋 작업 내용

상품 상세 페이지의 이미지뷰변경

### 변경된 내용

- 상품 상세 페이지 이미지뷰 변경

### 작업 상세 설명

1. 기존의 코드에서는 상품 페이지의 사진 개수가 5개로 정해져 있었으나, 이를 사진의 개수에 맞게 뷰포트의 위치가 적절히 조절되도록 함
---

## ✅ 체크리스트

- [v] 코드가 잘 빌드됨
- [v] Linter
- [v] 모든 테스트 통과
- [v] kanban update

---

## 💬 리뷰 요구사항

---
